### PR TITLE
Update api-general-info.md

### DIFF
--- a/src/content/docs/specification/v3_0/api-general-info.md
+++ b/src/content/docs/specification/v3_0/api-general-info.md
@@ -38,11 +38,11 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
 
-  # Link to the external documentation (if any).
-  # Code or documentation generation tools can use description as the text of the link.
-  externalDocs:
-    description: Find out more
-    url: http://example.com
+# Link to the external documentation (if any).
+# Code or documentation generation tools can use description as the text of the link.
+externalDocs:
+  description: Find out more
+  url: http://example.com
 ```
 
 The `title` and `version` properties are required, others are optional.


### PR DESCRIPTION
`externalDocs` is not part of the `info` Object, but instead top-level on the `OpenAPI` Object as can be seen here: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#infoObject

This PR simply moves the `externalDocs` to the top level `OpenAPI` Object.