### PR TITLE
chore(docs): update docs for codegen 2.4.45

### DIFF
--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/about.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/about.md
@@ -51,7 +51,7 @@ Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility
 
 Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.66-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
 2.4.46-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/swagger-codegen-cli/2.4.46-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
 
 For detailed breakdown of all versions, please see the [full compatibility listing](../compatibility).

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/about.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/about.md
@@ -45,14 +45,14 @@ The OpenAPI Specification has undergone 3 revisions since initial creation in 20
 Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
 [3.0.65](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.65) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.65](https://github.com/swagger-api/swagger-codegen/tree/v3.0.65)
-[2.4.44](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.44) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.44](https://github.com/swagger-api/swagger-codegen/tree/v2.4.43)
+[2.4.45](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.45) (**current stable**) | 2025-06-08   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.45](https://github.com/swagger-api/swagger-codegen/tree/v2.4.45)
 
 💁 Here's also an overview of what's coming around the corner:
 
 Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.66-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
-2.4.45-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.4.45-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
+3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.66-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+2.4.46-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/swagger-codegen-cli/2.4.46-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
 
 For detailed breakdown of all versions, please see the [full compatibility listing](../compatibility).
 
@@ -84,7 +84,7 @@ java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
 java -jar modules\swagger-codegen-cli\target\swagger-codegen-cli.jar generate -i https://petstore.swagger.io/v2/swagger.json -l php -o c:\temp\php_api_client
 ```
 
-You can also download the JAR (latest release) directly from [maven.org](https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.44/swagger-codegen-cli-2.4.44.jar)
+You can also download the JAR (latest release) directly from [maven.org](https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.45/swagger-codegen-cli-2.4.45.jar)
 
 To get a list of **general** options available, you can run the following:
 

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/about.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/about.md
@@ -44,14 +44,14 @@ The OpenAPI Specification has undergone 3 revisions since initial creation in 20
 
 Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-[3.0.65](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.65) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.65](https://github.com/swagger-api/swagger-codegen/tree/v3.0.65)
+[3.0.68](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.68) (**current stable**) | 2025-03-05   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.68](https://github.com/swagger-api/swagger-codegen/tree/v3.0.68)
 [2.4.45](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.45) (**current stable**) | 2025-06-08   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.45](https://github.com/swagger-api/swagger-codegen/tree/v2.4.45)
 
 💁 Here's also an overview of what's coming around the corner:
 
 Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+3.0.69-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
 2.4.46-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/swagger-codegen-cli/2.4.46-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
 
 For detailed breakdown of all versions, please see the [full compatibility listing](../compatibility).

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/compatibility.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/compatibility.md
@@ -10,7 +10,7 @@ The Swagger Codegen project has the following compatibilities with the OpenAPI S
 
 Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.66-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
 [3.0.65](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.65) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.65](https://github.com/swagger-api/swagger-codegen/tree/v3.0.65)
 [3.0.64](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.64) | 2024-11-07   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.64](https://github.com/swagger-api/swagger-codegen/tree/v3.0.64)
 [3.0.63](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.63) | 2024-10-16   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.63](https://github.com/swagger-api/swagger-codegen/tree/v3.0.63)
@@ -76,8 +76,9 @@ Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 [3.0.2](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.2)| 2018-10-19   | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
 [3.0.1](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.1)| 2018-10-05   | 1.0, 1.1, 1.2, 2.0, 3.0 | Major release with breaking changes
 [3.0.0](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.0)| 2018-09-06   | 1.0, 1.1, 1.2, 2.0, 3.0 | Major release with breaking changes
-2.4.45-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.4.45-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
-[2.4.44](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.44) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.44](https://github.com/swagger-api/swagger-codegen/tree/v2.4.44)
+2.4.46-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/swagger-codegen-cli/2.4.46-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
+[2.4.45](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.45) (**current stable**) | 2025-06-08   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.45](https://github.com/swagger-api/swagger-codegen/tree/v2.4.45)
+[2.4.44](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.44) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.44](https://github.com/swagger-api/swagger-codegen/tree/v2.4.44)
 [2.4.43](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.43) | 2024-08-09   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.43](https://github.com/swagger-api/swagger-codegen/tree/v2.4.43)
 [2.4.42](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.42) | 2024-07-29   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.42](https://github.com/swagger-api/swagger-codegen/tree/v2.4.42)
 [2.4.41](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.41) | 2024-04-22   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.41](https://github.com/swagger-api/swagger-codegen/tree/v2.4.41)

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/compatibility.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/compatibility.md
@@ -10,8 +10,11 @@ The Swagger Codegen project has the following compatibilities with the OpenAPI S
 
 Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.66-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
-[3.0.65](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.65) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.65](https://github.com/swagger-api/swagger-codegen/tree/v3.0.65)
+3.0.69-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+[3.0.68](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.68) (**current stable**) | 2025-03-05   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.68](https://github.com/swagger-api/swagger-codegen/tree/v3.0.68)
+[3.0.67](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.67) | 2025-01-27   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.67](https://github.com/swagger-api/swagger-codegen/tree/v3.0.67)
+[3.0.66](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.66) | 2024-12-23   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.66](https://github.com/swagger-api/swagger-codegen/tree/v3.0.66)
+[3.0.65](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.65) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.65](https://github.com/swagger-api/swagger-codegen/tree/v3.0.65)
 [3.0.64](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.64) | 2024-11-07   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.64](https://github.com/swagger-api/swagger-codegen/tree/v3.0.64)
 [3.0.63](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.63) | 2024-10-16   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.63](https://github.com/swagger-api/swagger-codegen/tree/v3.0.63)
 [3.0.62](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.62) | 2024-08-27   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.62](https://github.com/swagger-api/swagger-codegen/tree/v3.0.62)

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/prerequisites.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/prerequisites.md
@@ -10,7 +10,7 @@ If you're looking for the latest stable version, you can grab it directly from M
 
 ```sh
 # Download current stable 2.x.x branch (Swagger and OpenAPI version 2)
-wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.44/swagger-codegen-cli-2.4.44.jar -O swagger-codegen-cli.jar
+wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.45/swagger-codegen-cli-2.4.45.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar help
 
@@ -25,7 +25,7 @@ For Windows users, you will need to install [wget](http://gnuwin32.sourceforge.n
 example:
 
 ```powershell
-Invoke-WebRequest -OutFile swagger-codegen-cli.jar https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.44/swagger-codegen-cli-2.4.44.jar
+Invoke-WebRequest -OutFile swagger-codegen-cli.jar https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.45/swagger-codegen-cli-2.4.45.jar
 ```
 
 On a mac, it's even easier with `brew`:

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/versioning.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v2/versioning.md
@@ -26,7 +26,7 @@ dependency example:
 <dependency>
     <groupId>io.swagger</groupId>
     <artifactId>swagger-codegen-maven-plugin</artifactId>
-    <version>2.4.44</version>
+    <version>2.4.45</version>
 </dependency>
 ```
 

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v3/about.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v3/about.md
@@ -72,14 +72,14 @@ The OpenAPI Specification has undergone 3 revisions since initial creation in 20
 Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
 [3.0.68](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.68) (**current stable**) | 2025-03-05   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.68](https://github.com/swagger-api/swagger-codegen/tree/v3.0.68)
-[2.4.44](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.44) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.44](https://github.com/swagger-api/swagger-codegen/tree/v2.4.44)
+[2.4.45](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.45) (**current stable**) | 2025-06-08   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.45](https://github.com/swagger-api/swagger-codegen/tree/v2.4.45)
 
 💁 Here's also an overview of what's coming around the corner:
 
 Swagger Codegen Version    | Release Date | Swagger / OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.69-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
-2.4.45-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.4.45-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
+3.0.69-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+2.4.46-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/swagger-codegen-cli/2.4.46-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
 
 For detailed breakdown of all versions, please see the [full compatibility listing](../compatibility).
 

--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v3/compatibility.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v3/compatibility.md
@@ -10,7 +10,7 @@ The Swagger Codegen project has the following compatibilities with the OpenAPI S
 
 Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.69-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+3.0.69-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.69-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
 [3.0.68](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.68) (**current stable**) | 2025-03-05   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.68](https://github.com/swagger-api/swagger-codegen/tree/v3.0.68)
 [3.0.67](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.67) | 2025-01-27   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.67](https://github.com/swagger-api/swagger-codegen/tree/v3.0.67)
 [3.0.66](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.66) | 2024-12-23   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.66](https://github.com/swagger-api/swagger-codegen/tree/v3.0.66)
@@ -79,8 +79,9 @@ Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 [3.0.2](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.2)| 2018-10-19   | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
 [3.0.1](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.1)| 2018-10-05   | 1.0, 1.1, 1.2, 2.0, 3.0 | Major release with breaking changes
 [3.0.0](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.0)| 2018-09-06   | 1.0, 1.1, 1.2, 2.0, 3.0 | Major release with breaking changes
-2.4.45-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.4.45-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
-[2.4.44](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.44) (**current stable**) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.44](https://github.com/swagger-api/swagger-codegen/tree/v2.4.44)
+2.4.46-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/swagger/swagger-codegen-cli/2.4.46-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
+[2.4.45](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.45) (**current stable**) | 2025-06-08   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.45](https://github.com/swagger-api/swagger-codegen/tree/v2.4.45)
+[2.4.44](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.44) | 2024-12-18   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.44](https://github.com/swagger-api/swagger-codegen/tree/v2.4.44)
 [2.4.43](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.43) | 2024-08-09   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.43](https://github.com/swagger-api/swagger-codegen/tree/v2.4.43)
 [2.4.42](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.42) | 2024-07-29   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.42](https://github.com/swagger-api/swagger-codegen/tree/v2.4.42)
 [2.4.41](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.41) | 2024-04-22   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.41](https://github.com/swagger-api/swagger-codegen/tree/v2.4.41)

--- a/src/content/docs/open-source-tools/Swagger UI/Usage/configuration.md
+++ b/src/content/docs/open-source-tools/Swagger UI/Usage/configuration.md
@@ -228,7 +228,7 @@ Parameter name | Docker variable | Description
         <td><em>Unavailable</em></td>
         <td><code>String=["agate"*, "arta", "monokai", "nord", "obsidian",
             "tomorrow-night", "idea"]</code>. <a
-                href="https://highlightjs.org/static/demo/" rel="nofollow">Highlight.js</a>
+                href="https://highlightjs.org/demo/" rel="nofollow">Highlight.js</a>
             syntax coloring theme to use. (Only these 7 styles are available.)
         </td>
     </tr>


### PR DESCRIPTION
refs: https://github.com/swagger-api/swagger-codegen/pull/12553

update swagger docs site based on codegen 2.4.45 release