### PR TITLE
Fix typoes

### DIFF
--- a/src/content/docs/open-source-tools/Swagger Codegen/Codegen v3/docker.md
+++ b/src/content/docs/open-source-tools/Swagger Codegen/Codegen v3/docker.md
@@ -63,7 +63,7 @@ Image accepts the following env variables:
 
 - `JAVA_MEM` e.g. `1024m`
 - `HTTP_PORT` e.g. `8080`
-- `HIDDEN_OPTIONS_PATH` (alternative to `HIDDEN_OPTIONS`): useful if attaching a volume containing a `hiddenOptions.yaml` file definining which languages to hide. e.g. `/data/hiddenOptions.yaml`
+- `HIDDEN_OPTIONS_PATH` (alternative to `HIDDEN_OPTIONS`): useful if attaching a volume containing a `hiddenOptions.yaml` file defining which languages to hide. e.g. `/data/hiddenOptions.yaml`
 - `HIDDEN_OPTIONS` (alternative to `HIDDEN_OPTIONS_PATH`): allows to pass hidden options as an env variable, in the format `{category}:{language},{language},{language}|{category}:{language},{language},{language}`
 e.g. `servers:foo,bar|clientsV3:wtf,isthis` where category can be `clients`, `servers`, `clientsV3`, `serversV3`
 

--- a/src/content/docs/open-source-tools/swagger-editor-next.md
+++ b/src/content/docs/open-source-tools/swagger-editor-next.md
@@ -294,7 +294,7 @@ Usage in **development** environment:
  $ npm run cy:dev
 ```
 
-Usage in **Continuos Integration (CI)** environment:
+Usage in **Continuous Integration (CI)** environment:
 
 ```sh
  $ npm run cy:ci


### PR DESCRIPTION
Spotted one when reading through the codegen, so ran spellchecking over docs to find the other.

(a typo isn't a bug, else I'd have gone with `bug/*` for the branch name)

